### PR TITLE
Migrate base to Vue 3 with Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link rel="icon" href="/favicon.png" />
+    <title>Vuetify Material Dashboard - by Creative Tim</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,24 +3,26 @@
   "version": "2.1.0",
   "private": true,
   "scripts": {
-    "dev": "vue-cli-service serve --open",
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint",
+    "dev": "vite",
+    "serve": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
-    "now-start": "vue-cli-service serve",
+    "now-start": "vite",
     "test:e2e": "vue-cli-service test:e2e",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
     "core-js": "^3.6.2",
-    "vue": "^2.6.11",
-    "vue-i18n": "^8.15.3",
-    "vue-router": "^3.1.3",
-    "vuetify": "^2.2.11",
-    "vuex": "^3.1.2"
+    "vue": "^3.4.0",
+    "vue-i18n": "^9.0.0",
+    "vue-router": "^4.2.0",
+    "vuetify": "^3.0.0",
+    "vuex": "^4.0.2"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^4.0.0",
+    "vite": "^4.0.0",
     "@vue/cli-plugin-babel": "^4.1.2",
     "@vue/cli-plugin-e2e-cypress": "^4.1.2",
     "@vue/cli-plugin-eslint": "^4.1.2",
@@ -40,7 +42,6 @@
     "vue-chartist": "^2.2.1",
     "vue-cli-plugin-i18n": "^0.6.0",
     "vue-cli-plugin-vuetify": "^2.0.3",
-    "vue-template-compiler": "^2.6.11",
     "vue-world-map": "^0.1.1",
     "vuetify-loader": "^1.4.3"
   }

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ import vuetify from './plugins/vuetify'
 import i18n from './i18n'
 
 Vue.config.productionTip = false
+Vue.config.compatConfig = { MODE: 3 }
 
 new Vue({
   router,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      vue: '@vue/compat'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add simple Vite configuration
- create Vite `index.html`
- update scripts and deps for Vue 3/Vite
- enable Vue 2 compat mode

## Testing
- `npm run test:unit` *(fails: vue-cli-service not found)*
- `npm run test:e2e` *(fails: vue-cli-service not found)*